### PR TITLE
add python 3 compatibility

### DIFF
--- a/dmidecode.py
+++ b/dmidecode.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os, sys
 
 __version__ = "0.8.1"
 
@@ -76,7 +77,6 @@ def _parse_handle_section(lines):
 
 
 def profile():
-    import os, sys
     if os.isatty(sys.stdin.fileno()):
         content = _get_output()
     else:
@@ -88,9 +88,17 @@ def profile():
 
 def _get_output():
     import subprocess
-    output = subprocess.check_output(
+    try:
+        output = subprocess.check_output(
         'PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin '
         'sudo dmidecode', shell=True)
+    except Exception as e:
+        print(e, file=sys.stderr)
+        if str(e).find("command not found") == -1:
+            print("please install dmidecode", file=sys.stderr)
+            print("e.g. sudo apt install dmidecode",file=sys.stderr)
+
+        sys.exit(1)
     return output.decode()
 
 
@@ -99,9 +107,10 @@ def _show(info):
         return [v for j, v in info if j == i]
 
     system = _get('system')[0]
-    print ('%s %s (SN: %s, UUID: %s)' % (
+    print ('%s %s (Version:%s, SN: %s, UUID: %s)' % (
         system['Manufacturer'],
         system['Product Name'],
+        system['Version'],
         system['Serial Number'],
         system['UUID'],
         ))

--- a/dmidecode.py
+++ b/dmidecode.py
@@ -1,5 +1,6 @@
-__version__ = "0.8.1"
+from __future__ import print_function
 
+__version__ = "0.8.1"
 
 TYPE = {
     0:  'bios',
@@ -34,7 +35,7 @@ def parse_dmi(content):
     lines = iter(content.strip().splitlines())
     while True:
         try:
-            line = lines.next()
+            line = next(lines)
         except StopIteration:
             break
 
@@ -55,7 +56,7 @@ def _parse_handle_section(lines):
     * line started with two tabs is a member of list
     """
     data = {
-        '_title': lines.next().rstrip(),
+        '_title': next(lines).rstrip(),
         }
 
     for line in lines:
@@ -90,7 +91,7 @@ def _get_output():
     output = subprocess.check_output(
         'PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin '
         'sudo dmidecode', shell=True)
-    return output
+    return output.decode()
 
 
 def _show(info):
@@ -98,21 +99,26 @@ def _show(info):
         return [v for j, v in info if j == i]
 
     system = _get('system')[0]
-    print '%s %s (SN: %s, UUID: %s)' % (
+    print ('%s %s (SN: %s, UUID: %s)' % (
         system['Manufacturer'],
         system['Product Name'],
         system['Serial Number'],
         system['UUID'],
-        )
+        ))
 
     for cpu in _get('processor'):
-        print '%s %s %s (Core: %s, Thead: %s)' % (
+        #fix for output in virtual machine environments
+        if 'Thread Count' in cpu:
+            threads = cpu['Thread Count']
+        else:
+            threads = "-"
+        print ('%s %s %s (Core: %s, Thead: %s)' % (
             cpu['Manufacturer'],
             cpu['Family'],
             cpu['Max Speed'],
             cpu['Core Count'],
-            cpu['Thread Count'],
-            )
+            threads,
+            ))
 
     cnt, total, unit = 0, 0, None
     for mem in _get('memory device'):
@@ -121,11 +127,11 @@ def _show(info):
         i, unit = mem['Size'].split()
         cnt += 1
         total += int(i)
-    print '%d memory stick(s), %d %s in total' % (
+    print ('%d memory stick(s), %d %s in total' % (
         cnt,
         total,
         unit,
-        )
+        ))
 
 
 if __name__ == '__main__':

--- a/dmidecode.py
+++ b/dmidecode.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os, sys
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 TYPE = {
     0:  'bios',

--- a/dmidecode.py
+++ b/dmidecode.py
@@ -107,10 +107,9 @@ def _show(info):
         return [v for j, v in info if j == i]
 
     system = _get('system')[0]
-    print ('%s %s (Version:%s, SN: %s, UUID: %s)' % (
+    print ('%s %s (SN: %s, UUID: %s)' % (
         system['Manufacturer'],
         system['Product Name'],
-        system['Version'],
         system['Serial Number'],
         system['UUID'],
         ))
@@ -141,7 +140,13 @@ def _show(info):
         total,
         unit,
         ))
-
+    bios = _get('bios')[0]
+    print ('BIOS: %s v.%s %s Systemversion: %s' % (
+        bios['Vendor'],
+        bios['Version'],
+        bios['Release Date'],
+        system['Version']
+        ))
 
 if __name__ == '__main__':
     profile()

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Utilities',
         ],
     )

--- a/tests.py
+++ b/tests.py
@@ -95,3 +95,55 @@ System Information
             "Family": "Not Specified",
             })
 
+def test_cpu_vm():
+    output = """
+Handle 0x0004, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: CPU #000
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: F0 06 03 00 FF FB AB 1F
+	Version: Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 2600 MHz
+	Status: Populated, Enabled
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0018
+	L2 Cache Handle: 0x001C
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Core Count: 4
+	Core Enabled: 4
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Execute Protection
+"""
+    assert parse_dmi(output)[0] == ('processor',
+ {'Asset Tag': 'Not Specified',
+  'Characteristics': ['64-bit capable', 'Multi-Core', 'Execute Protection'],
+  'Core Count': '4',
+  'Core Enabled': '4',
+  'Current Speed': '2600 MHz',
+  'External Clock': 'Unknown',
+  'Family': 'Unknown',
+  'ID': 'F0 06 03 00 FF FB AB 1F',
+  'L1 Cache Handle': '0x0018',
+  'L2 Cache Handle': '0x001C',
+  'L3 Cache Handle': 'Not Provided',
+  'Manufacturer': 'GenuineIntel',
+  'Max Speed': '30000 MHz',
+  'Part Number': 'Not Specified',
+  'Serial Number': 'Not Specified',
+  'Socket Designation': 'CPU #000',
+  'Status': 'Populated, Enabled',
+  'Type': 'Central Processor',
+  'Upgrade': 'ZIF Socket',
+  'Version': 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
+  'Voltage': '3.3 V',
+  '_title': 'Processor Information'})


### PR DESCRIPTION
I have add some improvements to the library 
- add python 3 compatibility
- check for virtual machine environments (for vmware there are no threads)
- add testcase for virtual machine environments
- exception handling for missing dmidecode binary
- add bios version information to console output